### PR TITLE
Feature: get PinList and Update Metadata api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ serde_json = "1.0"
 walkdir = "2.3.1"
 failure = { version = "0.1.7" }
 log = "0.4.8"
+derive_builder = "0.9.0"
+
+[dev-dependencies]
+insta = "0.16.0"

--- a/src/api/data.rs
+++ b/src/api/data.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use crate::api::metadata::{PinMetadata, MetadataKeyValues, MetadataValue};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 /// All the currently supported regions on Pinata
@@ -88,20 +89,6 @@ pub struct PinByHashResult {
 }
 
 #[derive(Serialize)]
-/// Pin metadata stored along with files pinned.
-/// 
-/// The PinMetadata object will not be part of your content added to IPFS
-/// 
-/// Pinata simply stores the metadata provided to help you easily query 
-/// the content you've pinned with Pinata.
-pub struct PinMetadata {
-  /// Custom name used for referencing your pinned content.
-  pub name: Option<String>,
-  /// List of key value items to attach with the pinned content
-  pub keyvalues: HashMap<String, String>,
-}
-
-#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 /// Used to add additional options when pinning by hash
 pub struct PinOptions {
@@ -153,7 +140,7 @@ impl PinByHash {
   }
 
   /// Consumes the current PinByHash and returns a new PinByHash with keyvalues metadata set
-  pub fn set_metadata(self, keyvalues: HashMap<String, String>) -> PinByHash {
+  pub fn set_metadata(self, keyvalues: MetadataKeyValues) -> PinByHash {
     PinByHash {
       hash_to_pin: self.hash_to_pin,
       pinata_metadata: Some(PinMetadata {
@@ -165,7 +152,7 @@ impl PinByHash {
   }
 
   /// Consumes the current PinByHash and returns a new PinByHash with metadata name and keyvalues set
-  pub fn set_metadata_with_name<S>(self, name: S, keyvalues: HashMap<String, String>) -> PinByHash 
+  pub fn set_metadata_with_name<S>(self, name: S, keyvalues: HashMap<String, MetadataValue>) -> PinByHash 
     where S: Into<String>
   {
     PinByHash {
@@ -232,7 +219,7 @@ impl <S> PinByJson<S>
   }
 
   /// Consumes the current PinByJson<S> and returns a new PinByJson<S> with keyvalues metadata set
-  pub fn set_metadata(mut self, keyvalues: HashMap<String, String>) -> PinByJson<S> {
+  pub fn set_metadata(mut self, keyvalues: MetadataKeyValues) -> PinByJson<S> {
     self.pinata_metadata = Some(PinMetadata {
       name: None,
       keyvalues,
@@ -243,7 +230,7 @@ impl <S> PinByJson<S>
   /// Consumes the current PinByJson<S> and returns a new PinByJson<S> with keyvalues metadata set
   pub fn set_metadata_with_name<IntoStr>(
     mut self, name: IntoStr,
-    keyvalues: HashMap<String, String>
+    keyvalues: MetadataKeyValues
   ) -> PinByJson<S> 
     where IntoStr: Into<String>
   {
@@ -306,7 +293,7 @@ impl PinByFile {
   }
 
   /// Consumes the current PinByFile and returns a new PinByFile with keyvalues metadata set
-  pub fn set_metadata(mut self, keyvalues: HashMap<String, String>) -> PinByFile {
+  pub fn set_metadata(mut self, keyvalues: MetadataKeyValues) -> PinByFile {
     self.pinata_metadata = Some(PinMetadata {
       name: None,
       keyvalues,
@@ -317,7 +304,7 @@ impl PinByFile {
   /// Consumes the current PinByFile and returns a new PinByFile with keyvalues metadata set
   pub fn set_metadata_with_name<IntoStr>(
     mut self, name: IntoStr,
-    keyvalues: HashMap<String, String>
+    keyvalues: MetadataKeyValues
   ) -> PinByFile
     where IntoStr: Into<String>
   {

--- a/src/api/data.rs
+++ b/src/api/data.rs
@@ -431,3 +431,14 @@ pub struct PinnedObject {
   /// Timestamp for your content pinning in ISO8601 format
   pub timestamp: String
 }
+
+#[derive(Debug, Deserialize)]
+/// Results of a call to get total users pinned data
+pub struct TotalPinnedData {
+  /// The number of pins you currently have pinned with Pinata
+  pub pin_count: u128,
+  /// The total size of all unique content you have pinned with Pinata (expressed in bytes)
+  pub pin_size_total: String,
+  /// The total size of all content you have pinned with Pinata. This value is derived by multiplying the size of each piece of unique content by the number of times that content is replicated.
+  pub pin_size_with_replications_total: String,
+}

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
-use serde::{Serialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 /// Possible MetadaValues
 pub enum MetadataValue {
@@ -15,8 +15,6 @@ pub enum MetadataValue {
   Delete,
 }
 
-
-
 /// alias type for HashMap<String, MetadataValue>
 pub type MetadataKeyValues = HashMap<String, MetadataValue>;
 
@@ -28,6 +26,18 @@ pub struct PinMetadata {
   pub name: Option<String>,
   /// List of key value items to attach with the pinned content
   pub keyvalues: MetadataKeyValues,
+}
+
+#[derive(Debug, Deserialize)]
+/// Pin metadata returns from PinList query
+/// 
+/// This is different from [PinMetadata](struct.PinListMetadata.html) because
+/// keyvalues can also be optional in this result
+pub struct PinListMetadata {
+  /// Custom name used for referencing your pinned content.
+  pub name: Option<String>,
+  /// List of key value items to attach with the pinned content
+  pub keyvalues: Option<MetadataKeyValues>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+use serde::{Serialize};
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+/// Possible MetadaValues
+pub enum MetadataValue {
+  /// Represents a String metadata value
+  String(String),
+  /// Represents a float metadata value
+  Float(f64),
+  /// Represents an integer value
+  Integer(u64),
+  /// Only valid when used with a ChangePinMetadata request
+  Delete,
+}
+
+
+
+/// alias type for HashMap<String, MetadataValue>
+pub type MetadataKeyValues = HashMap<String, MetadataValue>;
+
+#[derive(Debug, Serialize)]
+/// Pin metadata stored along with files pinned.
+pub struct PinMetadata {
+  #[serde(skip_serializing_if = "Option::is_none")]
+  /// Custom name used for referencing your pinned content.
+  pub name: Option<String>,
+  /// List of key value items to attach with the pinned content
+  pub keyvalues: MetadataKeyValues,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+/// Pin metadata struct to update metadata of pinned items.
+/// 
+pub struct ChangePinMetadata {
+  /// Customx
+  pub ipfs_pin_hash: String,
+
+  #[serde(flatten)]
+  /// Updates to metadata for ipfs_pin_hash
+  pub metadata: PinMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashMap;
+  use serde_json::Value;
+  use super::{PinMetadata, MetadataValue};
+
+  #[test]
+  fn test_serialization_of_metadata() {
+    let mut keyvalues = HashMap::new();
+    keyvalues.insert("string".to_string(), MetadataValue::String("value".to_string()));
+    keyvalues.insert("number".to_string(), MetadataValue::Integer(10));
+    keyvalues.insert("delete".to_string(), MetadataValue::Delete);
+
+    let data = PinMetadata {
+      name: None,
+      keyvalues,
+    };
+
+    let json_value: Value = serde_json::from_str(
+      &serde_json::to_string(&data).unwrap()
+    ).unwrap();
+
+    // verify the structure of the json generated is similar to
+    // {
+    //   "keyvalues": {
+    //     "number": 10
+    //     "delete": Null,
+    //     "string": "value"
+    //   }
+    // }
+    if let Value::Object(object) = json_value {
+        if object.contains_key("name") {
+          assert!(false, "name fields of metadata should not exists")
+        }
+
+        if let Value::Object(keyvalues) = object.get("keyvalues").unwrap() {
+          if let Value::Null = keyvalues.get("delete").unwrap() { } else {
+            assert!(false, "keyvalues.delete should be null");
+          }
+
+          if let Value::String(string) = keyvalues.get("string").unwrap() {
+            assert_eq!("value", string);
+          } else {
+            assert!(false, "keyvalues.string is not a string");
+          }
+
+          if let Value::Number(number) = keyvalues.get("number").unwrap() {
+            assert_eq!(10, number.as_u64().unwrap());
+          } else {
+            assert!(false, "keyvalues.number is not a number");
+          }
+
+
+        } else {
+          assert!(false, "keyvalues fields of metadata should be an object");
+        }
+    } else {
+      assert!(false, "metadata not serialized as object");
+    }
+  }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,2 +1,3 @@
+pub mod metadata;
 pub mod data;
 pub mod internal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@
 
 #[cfg_attr(test, macro_use)]
 extern crate log;
+extern crate derive_builder;
 
 use std::fs;
 use std::path::Path;
@@ -258,6 +259,19 @@ impl PinataApi {
   /// This endpoint returns the total combined size for all content that you've pinned through Pinata
   pub async fn get_total_user_pinned_data(&self) ->  Result<TotalPinnedData, ApiError> {
     let response = self.client.get(&api_url("/data/userPinnedDataTotal"))
+      .send()
+      .await?;
+
+    self.parse_result(response).await
+  }
+
+  /// This returns data on what content the sender has pinned to IPFS from pinata
+  /// 
+  /// The purpose of this endpoint is to provide insight into what is being pinned, and how
+  /// long it has been pinned. The results of this call can be filtered using [PinListFilter](struct.PinListFilter.html).
+  pub async fn get_pin_list(&self, filters: PinListFilter) -> Result<PinList, ApiError> {
+    let response = self.client.get(&api_url("/data/pinList"))
+      .query(&filters)
       .send()
       .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ use utils::api_url;
 use api::internal::*;
 
 pub use api::data::*;
+pub use api::metadata::*;
 pub use errors::ApiError;
 
 mod api;
@@ -270,6 +271,21 @@ impl PinataApi {
   /// Unpin content previously uploaded to the Pinata's IPFS nodes.
   pub async fn unpin(&self, hash: &str) -> Result<(), ApiError> {
     let response = self.client.delete(&api_url(&format!("/pinning/unpin/{}", hash)))
+      .send()
+      .await?;
+
+    if response.status().is_success() {
+      Ok(())
+    } else {
+      let error = response.json::<PinataApiError>().await?;
+      Err(ApiError::GenericError(error.message()))
+    }
+  }
+
+  /// Change name and custom key values associated for a piece of content stored on Pinata.
+  pub async fn change_hash_metadata(&self, change: ChangePinMetadata) -> Result<(), ApiError> {
+    let response = self.client.put(&api_url("/pinning/hashMetadata"))
+      .json(&change)
       .send()
       .await?;
 

--- a/src/snapshots/pinata_sdk__tests__change_hash_metadata_pin_querying_works.snap
+++ b/src/snapshots/pinata_sdk__tests__change_hash_metadata_pin_querying_works.snap
@@ -1,0 +1,39 @@
+---
+source: src/tests.rs
+expression: pin_list
+---
+PinList {
+    count: 1,
+    rows: [
+        PinListItem {
+            id: "cc7f924f-7246-42ce-a1c7-f0067ac02144",
+            ipfs_pin_hash: "Qme5npQ51psDHssScnXqeKoUvA7UizxhRCfZi6ewMiiHcn",
+            size: 36,
+            user_id: "6176135e-fd99-4af9-a27c-23dd9d8e0461",
+            date_pinned: "2020-04-19T15:07:36.700Z",
+            data_unpinned: None,
+            metadata: PinListMetadata {
+                name: Some(
+                    "old-metadata-name",
+                ),
+                keyvalues: Some(
+                    {
+                        "to_be_preserved": Float(
+                            5.5,
+                        ),
+                        "new_value": String(
+                            "awesome",
+                        ),
+                    },
+                ),
+            },
+            regions: [
+                PinListItemRegionPolicy {
+                    region_id: FRA1,
+                    desired_replication_count: 1,
+                    current_replication_count: 1,
+                },
+            ],
+        },
+    ],
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -215,3 +215,18 @@ async fn test_change_hash_metadata_pin_querying_works() {
       Err(e) => assert!(false, "{}", e),
     }
 }
+
+#[tokio::test]
+async fn test_get_total_user_pinned_data() {
+  let result = get_api().get_total_user_pinned_data().await;
+
+  match result {
+    Ok(data) => {
+      debug!("{:?}", data);
+      assert_ne!(data.pin_count, 0);
+      assert_ne!(data.pin_size_total, "0");
+      assert_ne!(data.pin_size_with_replications_total, "0");
+    }
+    Err(e) => assert!(false, "{}", e),
+  }
+}


### PR DESCRIPTION
**CHANGELOG**
- Implements the new API for fetching pinned lists (`PinataApi::get_pin_list()`).
- Implements the new API for updating metadata information (`PinataApi::change_hash_metadata`).
- Implements the new API for fetching total user pinned data (`PinataApi::get_total_user_pinned_data).
- Breaking change: Move setter function on `PinJobFilter` to a new `PinJobFilterBuilder` struct