### PR TITLE
Fix dependency name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the crate as a dependency to your codebase
 
 ```toml
 [dependencies]
-pinata_sdk = "1.1.0"
+pinata-sdk = "1.1.0"
 ```
 
 ### Initializing the API


### PR DESCRIPTION
Though name of the crate is `pinata_sdk` but it is available to install as `pinata-sdk` ([https://github.com/perfectmak/pinata-sdk/blob/21d52d1a2a266d513b7cd0e6a84260543c1e982d/Cargo.toml#L2](link)).